### PR TITLE
Introduce Player Career Data Retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ To install run:
 
 `composer install`
 
-API documentation available at: http://api.performfeeds.com/soccerdata/matchstats/sdapidocumentation?_docu
+API documentation available at: https://documentation.statsperform.com/docs/rh/sdapi/Topics/soccer/index.htm

--- a/src/Endpoints/SdapiPlayerCareer.php
+++ b/src/Endpoints/SdapiPlayerCareer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sdapi\Endpoints;
+
+use Sdapi\SdapiEndpoint;
+
+class SdapiPlayerCareer extends SdapiEndpoint {
+
+  protected string $feedName = 'playercareer';
+
+  function getPlayerCareerDataForContestant(string $contestant_id): \stdClass {
+    return $this->get([], ['ctst' => $contestant_id]);
+  }
+
+}


### PR DESCRIPTION
This PR adds the SdapiPlayerCareer endpoint for fetching player career data by contestant ID, along with a minor README update.